### PR TITLE
Handle non-drum instruments

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The following descriptors are valid only for 16-step patterns:
 
 | Name         | Description                                 | Reference                                                                |
 |--------------|---------------------------------------------|--------------------------------------------------------------------------|
+| sync         | Syncopation                                 |                                                                          |
 | lowSync      | Syncopation of the low freq band            |                                                                          |
 | midSync      | Syncopation of the mid freq band            |                                                                          |
 | hiSync       | Syncopation of the high freq band           |                                                                          |

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ The following descriptors are valid only for 16-step patterns:
 | lowSync      | Syncopation of the low freq band            |                                                                          |
 | midSync      | Syncopation of the mid freq band            |                                                                          |
 | hiSync       | Syncopation of the high freq band           |                                                                          |
+| syness       | Syncopation / density                       |                                                                          |
 | lowSyness    | Syncopation / density of the low freq band  |                                                                          |
 | midSyness    | Syncopation / density of the mid freq band  |                                                                          |
 | hiSyness     | Syncopation / density of the high freq band |                                                                          |

--- a/README.md
+++ b/README.md
@@ -2,11 +2,7 @@
 
 This repository contains tools for studying rhythms in symbolic format. It was developed for the study of polyphonic
 drum patterns, but can be adapted for other types of patterns. It implements various descriptors derived from scientific
-papers for both monophonic and polyphonic patterns. See the [Descriptors](#descriptors) section below for a full list
-with references.
-
-To view the initial version of the toolbox (Nov 2018), checkout
-commit [`6acdb69a60153d08`](https://github.com/danielgomezmarin/rhythmtoolbox/tree/6acdb69a60153d0874da87560df3d7c62765e27a).
+literature; see [Descriptors](#descriptors) for a full list with references.
 
 ## Installation
 
@@ -81,33 +77,33 @@ The following descriptors are discussed in [Gómez-Marín et al, 2020](https://d
 Additional sources are listed where applicable. The mapping of MIDI instruments to frequency bands can be found
 in [midi_mapping.py](./rhythmtoolbox/midi_mapping.py).
 
-| Name    | Description                             |
-|---------|-----------------------------------------|
-| noi     | Number of instruments                   |
-| lowD    | Number of onsets in the low freq band   |
-| midD    | Number of onsets in the mid freq band   |
-| hiD     | Number of onsets in the high freq band  |
-| polyD   | Total number of onsets across all bands |
-| stepD   | Percentage of steps with onsets         |
-| lowness | Concentration in the low freq band      |
-| midness | Concentration in the mid freq band      |
-| hiness  | Concentration in the high freq band     |
+| Name        | Description                              |
+|-------------|------------------------------------------|
+| noi         | Number of instruments                    |
+| polyDensity | Number of onsets                         |
+| lowDensity  | Number of onsets in the low freq band    |
+| midDensity  | Number of onsets in the mid freq band    |
+| hiDensity   | Number of onsets in the high freq band   |
+| lowness     | Fraction of onsets in the low freq band  |
+| midness     | Fraction of onsets in the mid freq band  |
+| hiness      | Fraction of onsets in the high freq band |
+| stepDensity | Fraction of steps with onsets            |
 
 The following descriptors are valid only for 16-step patterns:
 
-| Name         | Description                                      | Reference                                                                |
-|--------------|--------------------------------------------------|--------------------------------------------------------------------------|
-| lowsync      | Syncopation of the low freq band                 |                                                                          |
-| midsync      | Syncopation of the mid instruments               |                                                                          |
-| hisync       | Syncopation of the high freq band                |                                                                          |
-| lowsyness    | Syncopation of the low freq band divided by lowD |                                                                          |
-| midsyness    | Syncopation of the mid freq band divided by midD |                                                                          |
-| hisyness     | Syncopation of the high freq band divided by hiD |                                                                          |
-| balance      | Monophonic balance                               | [Milne and Herff, 2020](https://doi.org/10.1016/j.cognition.2020.104233) |
-| evenness     | Monophonic evenness                              | [Milne and Dean, 2016](https://doi.org/10.1162/COMJ_a_00343)             |
-| polybalance  | Polyphonic balance                               |                                                                          |
-| polyevenness | Polyphonic evenness                              |                                                                          |
-| polysync     | Polyphonic syncopation                           | [Witek et al, 2014](https://doi.org/10.1371/journal.pone.0094446)        |
+| Name         | Description                                 | Reference                                                                |
+|--------------|---------------------------------------------|--------------------------------------------------------------------------|
+| lowSync      | Syncopation of the low freq band            |                                                                          |
+| midSync      | Syncopation of the mid freq band            |                                                                          |
+| hiSync       | Syncopation of the high freq band           |                                                                          |
+| lowSyness    | Syncopation / density of the low freq band  |                                                                          |
+| midSyness    | Syncopation / density of the mid freq band  |                                                                          |
+| hiSyness     | Syncopation / density of the high freq band |                                                                          |
+| balance      | Monophonic balance                          | [Milne and Herff, 2020](https://doi.org/10.1016/j.cognition.2020.104233) |
+| polyBalance  | Polyphonic balance                          |                                                                          |
+| evenness     | Monophonic evenness                         | [Milne and Dean, 2016](https://doi.org/10.1162/COMJ_a_00343)             |
+| polyEvenness | Polyphonic evenness                         |                                                                          |
+| polySync     | Polyphonic syncopation                      | [Witek et al, 2014](https://doi.org/10.<br/>1371/journal.pone.0094446)   |
 
 ## Attribution
 
@@ -125,6 +121,9 @@ via the BibTeX below.
       year={2020},
       publisher={Taylor \& Francis}
     }
+
+To cite the initial version of this repository (Nov 2018), checkout
+commit [`6acdb69a60153d08`](https://github.com/danielgomezmarin/rhythmtoolbox/tree/6acdb69a60153d0874da87560df3d7c62765e27a).
 
 The MIDI drum patterns examples included in [midi/boska](./midi/boska) and [midi/sano](./midi/sano) were provided by
 Jon-Eirik Boska and Sebastián Hoyos, respectively.

--- a/rhythmtoolbox/__init__.py
+++ b/rhythmtoolbox/__init__.py
@@ -41,7 +41,7 @@ def resample_pianoroll(roll, from_resolution, to_resolution):
     return ndimage.zoom(roll, (factor, 1), order=0)
 
 
-def pianoroll2descriptors(roll, resolution=4):
+def pianoroll2descriptors(roll, resolution=4, drums=True):
     """Compute all descriptors from a piano roll representation of a polyphonic drum pattern.
 
     Notes
@@ -55,6 +55,9 @@ def pianoroll2descriptors(roll, resolution=4):
         resolution, int
         The resolution of the piano roll in MIDI ticks per beat
 
+        drums, bool
+        Indicates whether the pattern is a drum pattern
+
     Returns
          Descriptors in a dict of {descriptor_name: descriptor_value}
     """
@@ -64,16 +67,19 @@ def pianoroll2descriptors(roll, resolution=4):
 
     descriptor_names = [
         "noi",
+        "stepDensity",
         "lowDensity",
         "midDensity",
         "hiDensity",
-        "stepDensity",
+        "polyDensity",
         "lowness",
         "midness",
         "hiness",
+        "sync",
         "lowSync",
         "midSync",
         "hiSync",
+        "polySync",
         "lowSyness",
         "midSyness",
         "hiSyness",
@@ -81,8 +87,6 @@ def pianoroll2descriptors(roll, resolution=4):
         "polyBalance",
         "evenness",
         "polyEvenness",
-        "polySync",
-        "polyDensity",
     ]
 
     # Initialize the return dict
@@ -96,9 +100,29 @@ def pianoroll2descriptors(roll, resolution=4):
     if n_onset_steps == 0:
         return result
 
+    pattern = (resampled.sum(axis=1) > 0).astype(int)
+
+    if not drums:
+        result["noi"] = noi(resampled)
+        result["stepDensity"] = step_density(resampled)
+        result["polyDensity"] = density(pattern)
+
+        if len(resampled) == 16:
+            result["balance"] = balance(pattern)
+            result["evenness"] = evenness(pattern)
+            result["sync"] = syncopation16(resampled)
+            result["syness"] = syness(pattern)
+
+        for desc in descriptor_names:
+            if desc not in result:
+                result[desc] = None
+
+        return result
+
     # Get the onset pattern of each frequency band
     low_band, mid_band, hi_band = get_bands(resampled)
 
+    # Compute descriptors that are valid for any pattern length
     result["noi"] = noi(resampled)
     result["lowDensity"] = density(low_band)
     result["midDensity"] = density(mid_band)
@@ -111,36 +135,59 @@ def pianoroll2descriptors(roll, resolution=4):
 
     # Compute descriptors that are valid only for 16-step patterns
     if len(resampled) == 16:
-        sixteen_step_descs = {}
-        sixteen_step_descs["lowSync"] = syncopation16(low_band)
-        sixteen_step_descs["midSync"] = syncopation16(mid_band)
-        sixteen_step_descs["hiSync"] = syncopation16(hi_band)
-        sixteen_step_descs["lowSyness"] = syness(low_band)
-        sixteen_step_descs["midSyness"] = syness(mid_band)
-        sixteen_step_descs["hiSyness"] = syness(hi_band)
-        sixteen_step_descs["polyBalance"] = poly_balance(low_band, mid_band, hi_band)
-        sixteen_step_descs["polyEvenness"] = poly_evenness(low_band, mid_band, hi_band)
-        sixteen_step_descs["polySync"] = poly_sync(low_band, mid_band, hi_band)
-        result.update(sixteen_step_descs)
+        result["sync"] = syncopation16(pattern)
+        result["lowSync"] = syncopation16(low_band)
+        result["midSync"] = syncopation16(mid_band)
+        result["hiSync"] = syncopation16(hi_band)
+        result["lowSyness"] = syness(low_band)
+        result["midSyness"] = syness(mid_band)
+        result["hiSyness"] = syness(hi_band)
+        result["balance"] = balance(pattern)
+        result["polyBalance"] = poly_balance(low_band, mid_band, hi_band)
+        result["evenness"] = evenness(pattern)
+        result["polyEvenness"] = poly_evenness(low_band, mid_band, hi_band)
+        result["polySync"] = poly_sync(low_band, mid_band, hi_band)
 
     return result
 
 
-def pattlist2descriptors(pattlist, resolution=4):
+def pattlist2descriptors(pattlist, resolution=4, drums=True):
     """Compute all descriptors from a pattern list representation of a polyphonic drum pattern.
 
     A pattern list is a list of lists representing time steps, each containing the MIDI note numbers that occur at that
     step, e.g. [[36, 42], [], [37], []]. Velocity is not included.
 
-    Some descriptors are valid only for 16-step patterns and will be None if the pattern length is not divisible by 16.
+    Parameters
+        pattlist, list
+        The pattern list
+
+        resolution, int
+        The resolution of the piano roll in MIDI ticks per beat
+
+        drums, bool
+        Indicates whether the pattern is a drum pattern
+
+    Returns
+         Descriptors in a dict of {descriptor_name: descriptor_value}
     """
     roll = pattlist_to_pianoroll(pattlist)
-    return pianoroll2descriptors(roll, resolution)
+    return pianoroll2descriptors(roll, resolution, drums=drums)
 
 
-def midifile2descriptors(midi_filepath):
-    """Compute all descriptors from a MIDI file."""
+def midifile2descriptors(midi_filepath, drums=True):
+    """Compute all descriptors from a MIDI file.
+
+    Parameters
+        midi_filepath, str
+        Path to a MIDI file
+
+        drums, bool
+        Indicates whether the pattern is a drum pattern
+
+    Returns
+         Descriptors in a dict of {descriptor_name: descriptor_value}
+    """
     import pypianoroll
 
     multitrack = pypianoroll.read(midi_filepath, resolution=4)
-    return pianoroll2descriptors(multitrack[0].pianoroll)
+    return pianoroll2descriptors(multitrack[0].pianoroll, drums=drums)

--- a/rhythmtoolbox/__init__.py
+++ b/rhythmtoolbox/__init__.py
@@ -19,6 +19,32 @@ from .descriptors import (
 from .midi_mapping import get_bands
 
 
+DESCRIPTOR_NAMES = [
+    "noi",
+    "polyDensity",
+    "lowDensity",
+    "midDensity",
+    "hiDensity",
+    "lowness",
+    "midness",
+    "hiness",
+    "stepDensity",
+    "sync",
+    "lowSync",
+    "midSync",
+    "hiSync",
+    "syness",
+    "lowSyness",
+    "midSyness",
+    "hiSyness",
+    "balance",
+    "polyBalance",
+    "evenness",
+    "polyEvenness",
+    "polySync",
+]
+
+
 def pattlist_to_pianoroll(pattlist):
     """Convert from a pattern list representation to a piano roll representation"""
     roll = np.zeros((len(pattlist), 128))
@@ -65,32 +91,8 @@ def pianoroll2descriptors(roll, resolution=4, drums=True):
     # Piano roll must be a 2D array
     assert len(roll.shape) == 2
 
-    descriptor_names = [
-        "noi",
-        "stepDensity",
-        "lowDensity",
-        "midDensity",
-        "hiDensity",
-        "polyDensity",
-        "lowness",
-        "midness",
-        "hiness",
-        "sync",
-        "lowSync",
-        "midSync",
-        "hiSync",
-        "polySync",
-        "lowSyness",
-        "midSyness",
-        "hiSyness",
-        "balance",
-        "polyBalance",
-        "evenness",
-        "polyEvenness",
-    ]
-
     # Initialize the return dict
-    result = {d: None for d in descriptor_names}
+    result = {d: None for d in DESCRIPTOR_NAMES}
 
     # Resample to a 16-note resolution
     resampled = resample_pianoroll(roll, resolution, 4)
@@ -113,7 +115,7 @@ def pianoroll2descriptors(roll, resolution=4, drums=True):
             result["sync"] = syncopation16(resampled)
             result["syness"] = syness(pattern)
 
-        for desc in descriptor_names:
+        for desc in DESCRIPTOR_NAMES:
             if desc not in result:
                 result[desc] = None
 
@@ -139,6 +141,7 @@ def pianoroll2descriptors(roll, resolution=4, drums=True):
         result["lowSync"] = syncopation16(low_band)
         result["midSync"] = syncopation16(mid_band)
         result["hiSync"] = syncopation16(hi_band)
+        result["syness"] = syness(pattern)
         result["lowSyness"] = syness(low_band)
         result["midSyness"] = syness(mid_band)
         result["hiSyness"] = syness(hi_band)

--- a/rhythmtoolbox/__init__.py
+++ b/rhythmtoolbox/__init__.py
@@ -1,7 +1,7 @@
 import numpy as np
 from scipy import ndimage
 
-from .descriptors import (
+from rhythmtoolbox.descriptors import (
     bandness,
     density,
     get_n_onset_steps,
@@ -16,8 +16,7 @@ from .descriptors import (
     syncopation16,
     syness,
 )
-from .midi_mapping import get_bands
-
+from rhythmtoolbox.midi_mapping import get_bands
 
 DESCRIPTOR_NAMES = [
     "noi",

--- a/rhythmtoolbox/descriptors.py
+++ b/rhythmtoolbox/descriptors.py
@@ -151,7 +151,7 @@ def get_n_onset_steps(roll):
     return (roll.sum(axis=1) > 0).sum()
 
 
-def stepD(roll):
+def step_density(roll):
     """Returns the percentage of steps with onsets"""
     return get_n_onset_steps(roll) / len(roll)
 
@@ -174,7 +174,7 @@ def syness(pattern):
     return syncopation16(pattern) / d if d else 0
 
 
-def polysync(lowstream, midstream, histream):
+def poly_sync(low_stream, mid_stream, hi_stream):
     """Computes the polyphonic syncopation of a rhythm, as described in [Witek et al., 2014].
 
     If N is a note that precedes a rest R, and R has a metric weight greater than or equal to N, then the pair (N, R)
@@ -183,23 +183,23 @@ def polysync(lowstream, midstream, histream):
     to constitute a polyphonic syncopation.
     """
 
-    # Metric profile as described by Witek et al
+    # Metric profile as described by Witek et al. (2014)
     salience_w = [0, -3, -2, -3, -1, -3, -2, -3, -1, -3, -2, -3, -1, -3, -2, -3]
     syncopation_list = []
 
     # number of time steps
-    n = len(lowstream)
+    n = len(low_stream)
 
     # find pairs of N and Ndi notes events
     for ix in range(n):
         # describe the instruments present in current and next steps
-        event = [lowstream[ix], midstream[ix], histream[ix]]
+        event = [low_stream[ix], mid_stream[ix], hi_stream[ix]]
 
         next_ix = (ix + 1) % n
         event_next = [
-            lowstream[next_ix],
-            midstream[next_ix],
-            histream[next_ix],
+            low_stream[next_ix],
+            mid_stream[next_ix],
+            hi_stream[next_ix],
         ]
 
         # syncopation occurs when adjacent events are different, and succeeding event has greater or equal metric weight
@@ -224,11 +224,11 @@ def polysync(lowstream, midstream, histream):
             if (event[0] == 1 or event[1] == 1) and event_next == [0, 0, 1]:
                 instrumental_weight = 5
 
-            # Low against mid (ATTENTION: not defined in [Witek et al., 2014])
+            # Low against mid (NOTE: not defined in [Witek et al., 2014])
             if event == [1, 0, 0] and event_next == [0, 1, 0]:
                 instrumental_weight = 2
 
-            # Mid against low (ATTENTION: not defined in [Witek et al., 2014])
+            # Mid against low (NOTE: not defined in [Witek et al., 2014])
             if event == [0, 1, 0] and event_next == [1, 0, 0]:
                 instrumental_weight = 2
 
@@ -242,37 +242,37 @@ def polysync(lowstream, midstream, histream):
     return sum(syncopation_list)
 
 
-def polyevenness(lowstream, midstream, histream):
+def poly_evenness(low_stream, mid_stream, hi_stream):
     """Compute the polyphonic evenness. Adapted from [Milne and Herff, 2020]"""
-    low_evenness = evenness(lowstream)
-    mid_evenness = evenness(midstream)
-    hi_evenness = evenness(histream)
+    low_evenness = evenness(low_stream)
+    mid_evenness = evenness(mid_stream)
+    hi_evenness = evenness(hi_stream)
 
     return low_evenness * 3 + mid_evenness * 2 + hi_evenness
 
 
-def polybalance(lowstream, midstream, histream):
+def poly_balance(low_stream, mid_stream, hi_stream):
     """Compute the polyphonic balance of a rhythm. Adapted from [Milne and Herff, 2020]"""
 
-    d = density(lowstream) * 3 + density(midstream) * 2 + density(histream)
+    d = density(low_stream) * 3 + density(mid_stream) * 2 + density(hi_stream)
     if d == 0:
         return 1
 
     center = np.array([0, 0])
     iso_angle_16 = 2 * math.pi / 16
 
-    Xlow = [3 * math.cos(i * iso_angle_16) for i, x in enumerate(lowstream) if x == 1]
-    Ylow = [3 * math.sin(i * iso_angle_16) for i, x in enumerate(lowstream) if x == 1]
+    Xlow = [3 * math.cos(i * iso_angle_16) for i, x in enumerate(low_stream) if x == 1]
+    Ylow = [3 * math.sin(i * iso_angle_16) for i, x in enumerate(low_stream) if x == 1]
     matrixlow = np.array([Xlow, Ylow])
     matrixlowsum = matrixlow.sum(axis=1)
 
-    Xmid = [2 * math.cos(i * iso_angle_16) for i, x in enumerate(midstream) if x == 1]
-    Ymid = [2 * math.sin(i * iso_angle_16) for i, x in enumerate(midstream) if x == 1]
+    Xmid = [2 * math.cos(i * iso_angle_16) for i, x in enumerate(mid_stream) if x == 1]
+    Ymid = [2 * math.sin(i * iso_angle_16) for i, x in enumerate(mid_stream) if x == 1]
     matrixmid = np.array([Xmid, Ymid])
     matrixmidsum = matrixmid.sum(axis=1)
 
-    Xhi = [2 * math.cos(i * iso_angle_16) for i, x in enumerate(histream) if x == 1]
-    Yhi = [2 * math.sin(i * iso_angle_16) for i, x in enumerate(histream) if x == 1]
+    Xhi = [2 * math.cos(i * iso_angle_16) for i, x in enumerate(hi_stream) if x == 1]
+    Yhi = [2 * math.sin(i * iso_angle_16) for i, x in enumerate(hi_stream) if x == 1]
     matrixhi = np.array([Xhi, Yhi])
     matrixhisum = matrixhi.sum(axis=1)
 
@@ -283,6 +283,6 @@ def polybalance(lowstream, midstream, histream):
     return 1 - magnitude
 
 
-def polyD(lowstream, midstream, histream):
+def poly_density(low_stream, mid_stream, hi_stream):
     # compute the total number of onsets
-    return density(lowstream) + density(midstream) + density(histream)
+    return density(low_stream) + density(mid_stream) + density(hi_stream)

--- a/rhythmtoolbox/descriptors.py
+++ b/rhythmtoolbox/descriptors.py
@@ -39,42 +39,42 @@ import numpy as np
 # Monophonic descriptors
 
 
-def syncopation16(patt):
+def syncopation16(pattern):
     """Compute the syncopation value of a 16-step pattern
 
-    patt, list
+    pattern, list
         a monophonic pattern as a list of 0s and 1s (1s indicating an onset)
     """
 
-    if isinstance(patt, np.ndarray):
-        patt = patt.tolist()
+    if isinstance(pattern, np.ndarray):
+        pattern = pattern.tolist()
 
     synclist = [0] * 16
     salience_lhl = [5, 1, 2, 1, 3, 1, 2, 1, 4, 1, 2, 1, 3, 1, 2, 1]
 
-    n_steps = len(patt)
+    n_steps = len(pattern)
     for ix in range(n_steps):
         next_ix = (ix + 1) % n_steps
         # look for an onset preceding a silence
-        if patt[ix] == 1 and patt[next_ix] == 0:
+        if pattern[ix] == 1 and pattern[next_ix] == 0:
             # compute syncopation
             synclist[ix] = salience_lhl[next_ix] - salience_lhl[ix]
 
     return sum(synclist)
 
 
-def syncopation16_awareness(patt):
+def syncopation16_awareness(pattern):
     # input a monophonic pattern as a list of 0s and 1s (1s indicating an onset)
     # and obtain its awareness-weighted syncopation value
     # awareness is reported in [2]
     synclist = [0] * 16
     salience = [5, 1, 2, 1, 3, 1, 2, 1, 4, 1, 2, 1, 3, 1, 2, 1]
     awareness = [5, 1, 4, 2]
-    n_steps = len(patt)
+    n_steps = len(pattern)
     for ix in range(n_steps):
         next_ix = (ix + 1) % n_steps
         # look for an onset and a silence following
-        if patt[ix] == 1 and patt[next_ix] == 0:
+        if pattern[ix] == 1 and pattern[next_ix] == 0:
             # compute syncopation
             synclist[ix] = salience[next_ix] - salience[ix]
 
@@ -89,7 +89,7 @@ def syncopation16_awareness(patt):
     return sum(sync_and_awareness)
 
 
-def evenness(patt):
+def evenness(pattern):
     # how well distributed are the D onsets of a pattern
     # if they are compared to a perfect D sided polygon
     # input patterns are phase-corrected to start always at step 0
@@ -97,36 +97,36 @@ def evenness(patt):
     # o1, o2, o3, o4 to positions 0 4 8 and 12
     # here we will use a simple algorithm that does not involve DFT computation
     # evenness is well described in [Milne and Dean, 2016] but this implementation is much simpler
-    d = density(patt)
+    d = density(pattern)
     if d == 0:
         return 0
 
     iso_angle_16 = 2 * math.pi / 16
-    first_onset_step = [i for i, x in enumerate(patt) if x == 1][0]
+    first_onset_step = [i for i, x in enumerate(pattern) if x == 1][0]
     first_onset_angle = first_onset_step * iso_angle_16
     iso_angle = 2 * math.pi / d
-    iso_patt_radians = [x * iso_angle for x in range(d)]
-    patt_radians = [i * iso_angle_16 for i, x in enumerate(patt) if x == 1]
+    iso_pattern_radians = [x * iso_angle for x in range(d)]
+    pattern_radians = [i * iso_angle_16 for i, x in enumerate(pattern) if x == 1]
     cosines = [
-        abs(math.cos(x - patt_radians[i] + first_onset_angle))
-        for i, x in enumerate(iso_patt_radians)
+        abs(math.cos(x - pattern_radians[i] + first_onset_angle))
+        for i, x in enumerate(iso_pattern_radians)
     ]
     return sum(cosines) / d
 
 
-def balance(patt):
+def balance(pattern):
     # balance is described in [Milne and Herff, 2020] as:
     # "a quantification of the proximity of that rhythm's
     # “centre of mass” (the mean position of the points)
     # to the centre of the unit circle."
-    d = density(patt)
+    d = density(pattern)
     if d == 0:
         return 1
 
     center = np.array([0, 0])
     iso_angle_16 = 2 * math.pi / 16
-    X = [math.cos(i * iso_angle_16) for i, x in enumerate(patt) if x == 1]
-    Y = [math.sin(i * iso_angle_16) for i, x in enumerate(patt) if x == 1]
+    X = [math.cos(i * iso_angle_16) for i, x in enumerate(pattern) if x == 1]
+    Y = [math.sin(i * iso_angle_16) for i, x in enumerate(pattern) if x == 1]
     matrix = np.array([X, Y])
     matrix_sum = matrix.sum(axis=1)
     magnitude = np.linalg.norm(matrix_sum - center) / d

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -17,184 +17,184 @@ from rhythmtoolbox import (
 def test_midifile2descriptors():
     v = midifile2descriptors("midi/boska/3.mid")
     assert v["noi"] == 5
-    assert v["lowD"] == 4
-    assert v["midD"] == 5
-    assert v["hiD"] == 10
-    assert v["stepD"] == 0.6875
+    assert v["lowDensity"] == 4
+    assert v["midDensity"] == 5
+    assert v["hiDensity"] == 10
+    assert v["stepDensity"] == 0.6875
     assert v["lowness"] == 0.36363636363636365
     assert v["midness"] == 0.45454545454545453
     assert v["hiness"] == 0.9090909090909091
-    assert v["lowsync"] == -7
-    assert v["midsync"] == -4
-    assert v["hisync"] == -10
-    assert v["lowsyness"] == -1.75
-    assert v["midsyness"] == -0.8
-    assert v["hisyness"] == -1.0
-    assert v["polysync"] == 9
-    assert v["polyevenness"] == 5.2753683906977775
-    assert v["polybalance"] == 0.9618538544571633
-    assert v["polyD"] == 19
+    assert v["lowSync"] == -7
+    assert v["midSync"] == -4
+    assert v["hiSync"] == -10
+    assert v["lowSyness"] == -1.75
+    assert v["midSyness"] == -0.8
+    assert v["hiSyness"] == -1.0
+    assert v["polySync"] == 9
+    assert v["polyEvenness"] == 5.2753683906977775
+    assert v["polyBalance"] == 0.9618538544571633
+    assert v["polyDensity"] == 19
 
     v = midifile2descriptors("midi/boska/8.mid")
     assert v["noi"] == 4
-    assert v["lowD"] == 6
-    assert v["midD"] == 10
-    assert v["hiD"] == 9
-    assert v["stepD"] == 1.0
+    assert v["lowDensity"] == 6
+    assert v["midDensity"] == 10
+    assert v["hiDensity"] == 9
+    assert v["stepDensity"] == 1.0
     assert v["lowness"] == 0.375
     assert v["midness"] == 0.625
     assert v["hiness"] == 0.5625
-    assert v["lowsync"] == 3
-    assert v["midsync"] == -4
-    assert v["hisync"] == -5
-    assert v["lowsyness"] == 0.5
-    assert v["midsyness"] == -0.4
-    assert v["hisyness"] == -0.5555555555555556
-    assert v["polysync"] == 7
-    assert v["polyevenness"] == 4.428794764473658
-    assert v["polybalance"] == 0.9961791398488665
-    assert v["polyD"] == 25
+    assert v["lowSync"] == 3
+    assert v["midSync"] == -4
+    assert v["hiSync"] == -5
+    assert v["lowSyness"] == 0.5
+    assert v["midSyness"] == -0.4
+    assert v["hiSyness"] == -0.5555555555555556
+    assert v["polySync"] == 7
+    assert v["polyEvenness"] == 4.428794764473658
+    assert v["polyBalance"] == 0.9961791398488665
+    assert v["polyDensity"] == 25
 
     v = midifile2descriptors("midi/boska/9.mid")
     assert v["noi"] == 6
-    assert v["lowD"] == 8
-    assert v["midD"] == 7
-    assert v["hiD"] == 9
-    assert v["stepD"] == 0.875
+    assert v["lowDensity"] == 8
+    assert v["midDensity"] == 7
+    assert v["hiDensity"] == 9
+    assert v["stepDensity"] == 0.875
     assert v["lowness"] == 0.5714285714285714
     assert v["midness"] == 0.5
     assert v["hiness"] == 0.6428571428571429
-    assert v["lowsync"] == 4
-    assert v["midsync"] == 2
-    assert v["hisync"] == -12
-    assert v["lowsyness"] == 0.5
-    assert v["midsyness"] == 0.2857142857142857
-    assert v["hisyness"] == -1.3333333333333333
-    assert v["polysync"] == 20
-    assert v["polyevenness"] == 4.9758868520193955
-    assert v["polybalance"] == 0.7964353630870814
-    assert v["polyD"] == 24
+    assert v["lowSync"] == 4
+    assert v["midSync"] == 2
+    assert v["hiSync"] == -12
+    assert v["lowSyness"] == 0.5
+    assert v["midSyness"] == 0.2857142857142857
+    assert v["hiSyness"] == -1.3333333333333333
+    assert v["polySync"] == 20
+    assert v["polyEvenness"] == 4.9758868520193955
+    assert v["polyBalance"] == 0.7964353630870814
+    assert v["polyDensity"] == 24
 
 
 def test_pianoroll2descriptors():
     v = pianoroll2descriptors(BOSKA_3)
     assert v["noi"] == 5
-    assert v["lowD"] == 4
-    assert v["midD"] == 5
-    assert v["hiD"] == 10
-    assert v["stepD"] == 0.6875
+    assert v["lowDensity"] == 4
+    assert v["midDensity"] == 5
+    assert v["hiDensity"] == 10
+    assert v["stepDensity"] == 0.6875
     assert v["lowness"] == 0.36363636363636365
     assert v["midness"] == 0.45454545454545453
     assert v["hiness"] == 0.9090909090909091
-    assert v["lowsync"] == -7
-    assert v["midsync"] == -4
-    assert v["hisync"] == -10
-    assert v["lowsyness"] == -1.75
-    assert v["midsyness"] == -0.8
-    assert v["hisyness"] == -1.0
-    assert v["polysync"] == 9
-    assert v["polyevenness"] == 5.2753683906977775
-    assert v["polybalance"] == 0.9618538544571633
-    assert v["polyD"] == 19
+    assert v["lowSync"] == -7
+    assert v["midSync"] == -4
+    assert v["hiSync"] == -10
+    assert v["lowSyness"] == -1.75
+    assert v["midSyness"] == -0.8
+    assert v["hiSyness"] == -1.0
+    assert v["polySync"] == 9
+    assert v["polyEvenness"] == 5.2753683906977775
+    assert v["polyBalance"] == 0.9618538544571633
+    assert v["polyDensity"] == 19
 
     v = pianoroll2descriptors(BOSKA_8)
     assert v["noi"] == 4
-    assert v["lowD"] == 6
-    assert v["midD"] == 10
-    assert v["hiD"] == 9
-    assert v["stepD"] == 1.0
+    assert v["lowDensity"] == 6
+    assert v["midDensity"] == 10
+    assert v["hiDensity"] == 9
+    assert v["stepDensity"] == 1.0
     assert v["lowness"] == 0.375
     assert v["midness"] == 0.625
     assert v["hiness"] == 0.5625
-    assert v["lowsync"] == 3
-    assert v["midsync"] == -4
-    assert v["hisync"] == -5
-    assert v["lowsyness"] == 0.5
-    assert v["midsyness"] == -0.4
-    assert v["hisyness"] == -0.5555555555555556
-    assert v["polysync"] == 7
-    assert v["polyevenness"] == 4.428794764473658
-    assert v["polybalance"] == 0.9961791398488665
-    assert v["polyD"] == 25
+    assert v["lowSync"] == 3
+    assert v["midSync"] == -4
+    assert v["hiSync"] == -5
+    assert v["lowSyness"] == 0.5
+    assert v["midSyness"] == -0.4
+    assert v["hiSyness"] == -0.5555555555555556
+    assert v["polySync"] == 7
+    assert v["polyEvenness"] == 4.428794764473658
+    assert v["polyBalance"] == 0.9961791398488665
+    assert v["polyDensity"] == 25
 
     v = pianoroll2descriptors(BOSKA_9)
     assert v["noi"] == 6
-    assert v["lowD"] == 8
-    assert v["midD"] == 7
-    assert v["hiD"] == 9
-    assert v["stepD"] == 0.875
+    assert v["lowDensity"] == 8
+    assert v["midDensity"] == 7
+    assert v["hiDensity"] == 9
+    assert v["stepDensity"] == 0.875
     assert v["lowness"] == 0.5714285714285714
     assert v["midness"] == 0.5
     assert v["hiness"] == 0.6428571428571429
-    assert v["lowsync"] == 4
-    assert v["midsync"] == 2
-    assert v["hisync"] == -12
-    assert v["lowsyness"] == 0.5
-    assert v["midsyness"] == 0.2857142857142857
-    assert v["hisyness"] == -1.3333333333333333
-    assert v["polysync"] == 20
-    assert v["polyevenness"] == 4.9758868520193955
-    assert v["polybalance"] == 0.7964353630870814
-    assert v["polyD"] == 24
+    assert v["lowSync"] == 4
+    assert v["midSync"] == 2
+    assert v["hiSync"] == -12
+    assert v["lowSyness"] == 0.5
+    assert v["midSyness"] == 0.2857142857142857
+    assert v["hiSyness"] == -1.3333333333333333
+    assert v["polySync"] == 20
+    assert v["polyEvenness"] == 4.9758868520193955
+    assert v["polyBalance"] == 0.7964353630870814
+    assert v["polyDensity"] == 24
 
 
 def test_pattlist2descriptors():
     v = pattlist2descriptors(BOSKA_3_PATTLIST)
     assert v["noi"] == 5
-    assert v["lowD"] == 4
-    assert v["midD"] == 5
-    assert v["hiD"] == 10
-    assert v["stepD"] == 0.6875
+    assert v["lowDensity"] == 4
+    assert v["midDensity"] == 5
+    assert v["hiDensity"] == 10
+    assert v["stepDensity"] == 0.6875
     assert v["lowness"] == 0.36363636363636365
     assert v["midness"] == 0.45454545454545453
     assert v["hiness"] == 0.9090909090909091
-    assert v["lowsync"] == -7
-    assert v["midsync"] == -4
-    assert v["hisync"] == -10
-    assert v["lowsyness"] == -1.75
-    assert v["midsyness"] == -0.8
-    assert v["hisyness"] == -1.0
-    assert v["polysync"] == 9
-    assert v["polyevenness"] == 5.2753683906977775
-    assert v["polybalance"] == 0.9618538544571633
-    assert v["polyD"] == 19
+    assert v["lowSync"] == -7
+    assert v["midSync"] == -4
+    assert v["hiSync"] == -10
+    assert v["lowSyness"] == -1.75
+    assert v["midSyness"] == -0.8
+    assert v["hiSyness"] == -1.0
+    assert v["polySync"] == 9
+    assert v["polyEvenness"] == 5.2753683906977775
+    assert v["polyBalance"] == 0.9618538544571633
+    assert v["polyDensity"] == 19
 
     v = pattlist2descriptors(BOSKA_8_PATTLIST)
     assert v["noi"] == 4
-    assert v["lowD"] == 6
-    assert v["midD"] == 10
-    assert v["hiD"] == 9
-    assert v["stepD"] == 1.0
+    assert v["lowDensity"] == 6
+    assert v["midDensity"] == 10
+    assert v["hiDensity"] == 9
+    assert v["stepDensity"] == 1.0
     assert v["lowness"] == 0.375
     assert v["midness"] == 0.625
     assert v["hiness"] == 0.5625
-    assert v["lowsync"] == 3
-    assert v["midsync"] == -4
-    assert v["hisync"] == -5
-    assert v["lowsyness"] == 0.5
-    assert v["midsyness"] == -0.4
-    assert v["hisyness"] == -0.5555555555555556
-    assert v["polysync"] == 7
-    assert v["polyevenness"] == 4.428794764473658
-    assert v["polybalance"] == 0.9961791398488665
-    assert v["polyD"] == 25
+    assert v["lowSync"] == 3
+    assert v["midSync"] == -4
+    assert v["hiSync"] == -5
+    assert v["lowSyness"] == 0.5
+    assert v["midSyness"] == -0.4
+    assert v["hiSyness"] == -0.5555555555555556
+    assert v["polySync"] == 7
+    assert v["polyEvenness"] == 4.428794764473658
+    assert v["polyBalance"] == 0.9961791398488665
+    assert v["polyDensity"] == 25
 
     v = pattlist2descriptors(BOSKA_9_PATTLIST)
     assert v["noi"] == 6
-    assert v["lowD"] == 8
-    assert v["midD"] == 7
-    assert v["hiD"] == 9
-    assert v["stepD"] == 0.875
+    assert v["lowDensity"] == 8
+    assert v["midDensity"] == 7
+    assert v["hiDensity"] == 9
+    assert v["stepDensity"] == 0.875
     assert v["lowness"] == 0.5714285714285714
     assert v["midness"] == 0.5
     assert v["hiness"] == 0.6428571428571429
-    assert v["lowsync"] == 4
-    assert v["midsync"] == 2
-    assert v["hisync"] == -12
-    assert v["lowsyness"] == 0.5
-    assert v["midsyness"] == 0.2857142857142857
-    assert v["hisyness"] == -1.3333333333333333
-    assert v["polysync"] == 20
-    assert v["polyevenness"] == 4.9758868520193955
-    assert v["polybalance"] == 0.7964353630870814
-    assert v["polyD"] == 24
+    assert v["lowSync"] == 4
+    assert v["midSync"] == 2
+    assert v["hiSync"] == -12
+    assert v["lowSyness"] == 0.5
+    assert v["midSyness"] == 0.2857142857142857
+    assert v["hiSyness"] == -1.3333333333333333
+    assert v["polySync"] == 20
+    assert v["polyEvenness"] == 4.9758868520193955
+    assert v["polyBalance"] == 0.7964353630870814
+    assert v["polyDensity"] == 24

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -96,46 +96,130 @@ def test_pianoroll2descriptors():
     assert v["polyEvenness"] == 5.2753683906977775
     assert v["polyBalance"] == 0.9618538544571633
     assert v["polyDensity"] == 19
+    assert v["syness"] == -0.6363636363636364
+    assert v["balance"] == 0.8855199884772941
+    assert v["evenness"] == 0.9649989736702275
+    assert v["sync"] == -7
+
+    v = pianoroll2descriptors(BOSKA_3, drums=False)
+    assert v["noi"] == 5
+    assert v["stepDensity"] == 0.6875
+    assert v["polyDensity"] == 11
+    assert v["sync"] == 0
+    assert v["balance"] == 0.8855199884772941
+    assert v["evenness"] == 0.9649989736702275
+    assert v["syness"] == -0.6363636363636364
+    assert v["lowDensity"] is None
+    assert v["midDensity"] is None
+    assert v["hiDensity"] is None
+    assert v["lowness"] is None
+    assert v["midness"] is None
+    assert v["hiness"] is None
+    assert v["lowSync"] is None
+    assert v["midSync"] is None
+    assert v["hiSync"] is None
+    assert v["polySync"] is None
+    assert v["lowSyness"] is None
+    assert v["midSyness"] is None
+    assert v["hiSyness"] is None
+    assert v["polyBalance"] is None
+    assert v["polyEvenness"] is None
 
     v = pianoroll2descriptors(BOSKA_8)
     assert v["noi"] == 4
+    assert v["stepDensity"] == 1.0
     assert v["lowDensity"] == 6
     assert v["midDensity"] == 10
     assert v["hiDensity"] == 9
-    assert v["stepDensity"] == 1.0
+    assert v["polyDensity"] == 25
     assert v["lowness"] == 0.375
     assert v["midness"] == 0.625
     assert v["hiness"] == 0.5625
+    assert v["sync"] == 0
     assert v["lowSync"] == 3
     assert v["midSync"] == -4
     assert v["hiSync"] == -5
+    assert v["polySync"] == 7
     assert v["lowSyness"] == 0.5
     assert v["midSyness"] == -0.4
     assert v["hiSyness"] == -0.5555555555555556
-    assert v["polySync"] == 7
-    assert v["polyEvenness"] == 4.428794764473658
+    assert v["balance"] == 0.9999999999999999
     assert v["polyBalance"] == 0.9961791398488665
-    assert v["polyDensity"] == 25
+    assert v["evenness"] == 1.0
+    assert v["polyEvenness"] == 4.428794764473658
+    assert v["syness"] == 0.0
+
+    v = pianoroll2descriptors(BOSKA_8, drums=False)
+    assert v["noi"] == 4
+    assert v["stepDensity"] == 1.0
+    assert v["polyDensity"] == 16
+    assert v["sync"] == 0
+    assert v["balance"] == 0.9999999999999999
+    assert v["evenness"] == 1.0
+    assert v["syness"] == 0.0
+    assert v["lowDensity"] is None
+    assert v["midDensity"] is None
+    assert v["hiDensity"] is None
+    assert v["lowness"] is None
+    assert v["midness"] is None
+    assert v["hiness"] is None
+    assert v["lowSync"] is None
+    assert v["midSync"] is None
+    assert v["hiSync"] is None
+    assert v["polySync"] is None
+    assert v["lowSyness"] is None
+    assert v["midSyness"] is None
+    assert v["hiSyness"] is None
+    assert v["polyBalance"] is None
+    assert v["polyEvenness"] is None
 
     v = pianoroll2descriptors(BOSKA_9)
     assert v["noi"] == 6
+    assert v["stepDensity"] == 0.875
     assert v["lowDensity"] == 8
     assert v["midDensity"] == 7
     assert v["hiDensity"] == 9
-    assert v["stepDensity"] == 0.875
+    assert v["polyDensity"] == 24
     assert v["lowness"] == 0.5714285714285714
     assert v["midness"] == 0.5
     assert v["hiness"] == 0.6428571428571429
+    assert v["sync"] == -3
     assert v["lowSync"] == 4
     assert v["midSync"] == 2
     assert v["hiSync"] == -12
+    assert v["polySync"] == 20
     assert v["lowSyness"] == 0.5
     assert v["midSyness"] == 0.2857142857142857
     assert v["hiSyness"] == -1.3333333333333333
-    assert v["polySync"] == 20
-    assert v["polyEvenness"] == 4.9758868520193955
+    assert v["balance"] == 0.8680172096412447
     assert v["polyBalance"] == 0.7964353630870814
-    assert v["polyDensity"] == 24
+    assert v["evenness"] == 0.9551143976077295
+    assert v["polyEvenness"] == 4.9758868520193955
+    assert v["syness"] == -0.21428571428571427
+
+    v = pianoroll2descriptors(BOSKA_9, drums=False)
+    assert v["noi"] == 6
+    assert v["stepDensity"] == 0.875
+    assert v["polyDensity"] == 14
+    assert v["sync"] == 0
+    assert v["balance"] == 0.8680172096412447
+    assert v["evenness"] == 0.9551143976077295
+    assert v["syness"] == -0.21428571428571427
+    assert v["lowDensity"] is None
+    assert v["midDensity"] is None
+    assert v["hiDensity"] is None
+    assert v["lowness"] is None
+    assert v["midness"] is None
+    assert v["hiness"] is None
+    assert v["lowSync"] is None
+    assert v["midSync"] is None
+    assert v["hiSync"] is None
+    assert v["polySync"] is None
+    assert v["lowSyness"] is None
+    assert v["midSyness"] is None
+    assert v["hiSyness"] is None
+    assert v["polyBalance"] is None
+    assert v["polyEvenness"] is None
 
 
 def test_pattlist2descriptors():

--- a/tests/test_rhythm_descriptors.py
+++ b/tests/test_rhythm_descriptors.py
@@ -7,11 +7,11 @@ from rhythmtoolbox.descriptors import (
     evenness,
     get_n_onset_steps,
     noi,
-    polybalance,
-    polyD,
-    polyevenness,
-    polysync,
-    stepD,
+    poly_balance,
+    poly_density,
+    poly_evenness,
+    poly_sync,
+    step_density,
     syncopation16,
     syncopation16_awareness,
     syness,
@@ -57,10 +57,10 @@ def test_density():
     assert density(hiband) == 9
 
 
-def test_stepD():
-    assert stepD(BOSKA_3) == 0.6875
-    assert stepD(BOSKA_8) == 1.0
-    assert stepD(BOSKA_9) == 0.875
+def test_stepDensity():
+    assert step_density(BOSKA_3) == 0.6875
+    assert step_density(BOSKA_8) == 1.0
+    assert step_density(BOSKA_9) == 0.875
 
 
 def test_bandness():
@@ -118,45 +118,45 @@ def test_syness():
     assert syness(hiband) == -1.3333333333333333
 
 
-def test_polysync():
+def test_polySync():
     lowband, midband, hiband = get_bands(BOSKA_3)
-    assert polysync(lowband, midband, hiband) == 9
+    assert poly_sync(lowband, midband, hiband) == 9
 
     lowband, midband, hiband = get_bands(BOSKA_8)
-    assert polysync(lowband, midband, hiband) == 7
+    assert poly_sync(lowband, midband, hiband) == 7
 
     lowband, midband, hiband = get_bands(BOSKA_9)
-    assert polysync(lowband, midband, hiband) == 20
+    assert poly_sync(lowband, midband, hiband) == 20
 
 
-def test_polyevenness():
+def test_polyEvenness():
     lowband, midband, hiband = get_bands(BOSKA_3)
-    assert polyevenness(lowband, midband, hiband) == 5.2753683906977775
+    assert poly_evenness(lowband, midband, hiband) == 5.2753683906977775
 
     lowband, midband, hiband = get_bands(BOSKA_8)
-    assert polyevenness(lowband, midband, hiband) == 4.428794764473658
+    assert poly_evenness(lowband, midband, hiband) == 4.428794764473658
 
     lowband, midband, hiband = get_bands(BOSKA_9)
-    assert polyevenness(lowband, midband, hiband) == 4.9758868520193955
+    assert poly_evenness(lowband, midband, hiband) == 4.9758868520193955
 
 
-def test_polybalance():
+def test_polyBalance():
     lowband, midband, hiband = get_bands(BOSKA_3)
-    assert polybalance(lowband, midband, hiband) == 0.9618538544571633
+    assert poly_balance(lowband, midband, hiband) == 0.9618538544571633
 
     lowband, midband, hiband = get_bands(BOSKA_8)
-    assert polybalance(lowband, midband, hiband) == 0.9961791398488665
+    assert poly_balance(lowband, midband, hiband) == 0.9961791398488665
 
     lowband, midband, hiband = get_bands(BOSKA_9)
-    assert polybalance(lowband, midband, hiband) == 0.7964353630870814
+    assert poly_balance(lowband, midband, hiband) == 0.7964353630870814
 
 
-def test_polyD():
+def test_polyDensity():
     lowband, midband, hiband = get_bands(BOSKA_3)
-    assert polyD(lowband, midband, hiband) == 19
+    assert poly_density(lowband, midband, hiband) == 19
 
     lowband, midband, hiband = get_bands(BOSKA_8)
-    assert polyD(lowband, midband, hiband) == 25
+    assert poly_density(lowband, midband, hiband) == 25
 
     lowband, midband, hiband = get_bands(BOSKA_9)
-    assert polyD(lowband, midband, hiband) == 24
+    assert poly_density(lowband, midband, hiband) == 24


### PR DESCRIPTION
Add a `drums` boolean parameter to the entrypoint functions to indicate whether the input rhythm is from a drum or not. For non-drum instruments, we omit the descriptors that require splitting the input into low/mid/hi bands, since these splits are based on perceptual research that is applicable only to drum rhythms. The descriptors that are valid for non-drum instruments are:

- noi
- stepDensity
- polyDensity
- balance
- evenness
- sync
- syness

This means we added four new descriptors to the result object: `balance`, `evenness`, `sync`, and `syness`. These were previously only used as intermediate values to calculate low/mid/hi/poly descriptors, but now we include them in the output because they are not redundant for non-drum instruments.

Also included a few improvements like consistently using camelCase for descriptor names, consistently using snake_case for function names, expanding "D" to "Density", and moving the list of descriptor names out of a function so that it can be imported.